### PR TITLE
chore: remove Turnstile/Supabase function and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,2 @@
-PUBLIC_TURNSTILE_SITE_KEY=your_turnstile_site_key
-TURNSTILE_SECRET_KEY=your_turnstile_secret_key
-SUPABASE_URL=https://your-project-id.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
+# Example environment file
+# No environment variables are required

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Track Attack Running
+
+Static site powered by [Astro](https://astro.build/).
+
+## Contact form
+
+This project uses [Netlify Forms](https://docs.netlify.com/forms/setup/) with reCAPTCHA v2 for contact submissions.
+
+1. Include a form on the site with `data-netlify="true"` and a `name` of `contact`.
+2. Add `<div data-netlify-recaptcha="true"></div>` inside the form to enable reCAPTCHA v2.
+3. Deploy the site. Forms appear in Netlify after the first successful submission.
+4. In Netlify, enable email notifications: Forms → select "contact" → Notifications → Email → recipient `tony@trackattackrunning.com`.
+

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -1,14 +1,14 @@
----
-const siteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
----
 <section id="contact" class="max-w-4xl mx-auto p-6">
   <h2 class="text-2xl font-bold">Contact Us</h2>
-  <form method="POST" class="mt-4 grid gap-4">
-    <input type="text" name="name" placeholder="Name" required class="border p-2 rounded">
-    <input type="email" name="email" placeholder="Email" required class="border p-2 rounded">
+  <form name="contact" method="POST" data-netlify="true" netlify-honeypot="bot-field" class="mt-4 grid gap-4">
+    <input type="hidden" name="form-name" value="contact" />
+    <p class="hidden">
+      <label>Don't fill this out if you're human: <input name="bot-field" /></label>
+    </p>
+    <input type="text" name="name" placeholder="Name" required class="border p-2 rounded" />
+    <input type="email" name="email" placeholder="Email" required class="border p-2 rounded" />
     <textarea name="message" placeholder="Message" required class="border p-2 rounded"></textarea>
-    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
-    <div class="cf-turnstile" data-sitekey={siteKey}></div>
+    <div data-netlify-recaptcha="true"></div>
     <button type="submit" class="px-4 py-2 bg-primary text-white rounded">Send</button>
   </form>
 </section>


### PR DESCRIPTION
## Summary
- drop obsolete Turnstile/Supabase env vars
- switch contact form to Netlify Forms with reCAPTCHA v2
- document Netlify Forms setup and email notification configuration

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689724f23f788329ae1c790c9d17612c