### PR TITLE
feat: redesigned header/footer + legal pages

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="48" fill="white" stroke="#D7322A" stroke-width="4"/>
+  <text x="50" y="60" text-anchor="middle" font-size="40" font-family="Arial, sans-serif" font-weight="bold" fill="#D7322A">TAR</text>
+</svg>

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -17,8 +17,8 @@
     rendering that might remove it during build, otherwise Netlify won't
     recognize it.
   -->
-  <form id="contact-form" name="track-attack-running-contact-us" method="POST" data-netlify="true" netlify-honeypot="bot-field" class="mt-4 grid gap-4">
-      <input type="hidden" name="form-name" value="track-attack-running-contact-us">
+    <form id="contact-form" name="track-attack-running-contact-us" method="POST" data-netlify="true" netlify-honeypot="bot-field" class="mt-4 grid gap-4">
+        <input type="hidden" name="form-name" value="track-attack-running-contact-us">
     <p class="hidden">
       <label>Don't fill this out if you're human: <input name="bot-field" /></label>
     </p>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -15,23 +15,26 @@ const { title = "Track Attack Running", description = "Fun, fast group workouts 
     <meta name="theme-color" content="#D7322A" />
     <link rel="stylesheet" href="/styles/base.css">
   </head>
-  <body class="bg-white text-gray-900">
-    <header class="p-4 bg-primary text-white">
-      <nav class="max-w-6xl mx-auto flex justify-between">
-        <a href="/">Track Attack Running</a>
-        <div class="space-x-4">
-          <a href="#about">About</a>
-          <a href="#book">Book</a>
-          <a href="#contact">Contact</a>
+    <body class="bg-white text-gray-900">
+      <header class="relative overflow-visible bg-gradient-to-r from-primary via-accent to-accentLight text-white">
+        <nav class="max-w-6xl mx-auto flex justify-end p-4">
+          <a href="#contact" class="font-medium hover:underline">Contact</a>
+        </nav>
+        <img src="/logo.svg" alt="Track Attack Running logo" class="absolute left-4 bottom-0 translate-y-1/2 w-20 h-auto" />
+      </header>
+      <main class="pt-12">
+        <slot />
+      </main>
+      <footer class="bg-gradient-to-r from-primary via-accent to-accentLight text-white mt-10">
+        <div class="max-w-6xl mx-auto flex flex-col sm:flex-row justify-between items-center p-4 text-sm">
+          <p class="mb-2 sm:mb-0">© 2025 Track Attack Running<sup class="align-super text-xs">TM</sup></p>
+          <div class="space-x-4">
+            <a href="/terms" class="hover:underline">Terms of Use</a>
+            <a href="/privacy" class="hover:underline">Privacy Policy</a>
+            <a href="#contact" class="hover:underline">Contact</a>
+          </div>
         </div>
-      </nav>
-    </header>
-    <main>
-      <slot />
-    </main>
-    <footer class="p-4 text-center text-sm text-gray-500 border-t mt-10">
-      © {new Date().getFullYear()} Track Attack Running
-    </footer>
-    <CommitInfo />
-  </body>
-</html>
+      </footer>
+      <CommitInfo />
+    </body>
+  </html>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,23 @@
+---
+import Layout from "../layouts/Layout.astro";
+---
+<Layout title="Privacy Policy">
+  <section class="prose mx-auto p-6">
+    <h1>Privacy Policy</h1>
+    <p><strong>Effective Date: January 1, 2024</strong></p>
+    <p>Track Attack Running, LLC ("we," "us," or "our") respects your privacy. This policy explains how we collect, use, and protect your information when you interact with our website and services.</p>
+    <h2>Information We Collect</h2>
+    <p>We collect information you voluntarily provide, such as your name, email address, and any message you submit through our contact form.</p>
+    <h2>How We Use Information</h2>
+    <p>Your information is used to respond to inquiries and provide coaching services. We do not sell your personal data.</p>
+    <h2>Cookies & Analytics</h2>
+    <p>Our site may use cookies or similar technologies to improve your experience and analyze traffic.</p>
+    <h2>Your Choices</h2>
+    <p>You may contact us to access or delete the information we have about you.</p>
+    <h2>Changes to This Policy</h2>
+    <p>We may update this Privacy Policy from time to time. Any changes will be posted on this page with a revised effective date.</p>
+    <h2>Contact Us</h2>
+    <p>If you have questions about this policy, reach us at:</p>
+    <address>Track Attack Running, LLC<br>1117 River Rock Drive<br>Folsom, CA 95630</address>
+  </section>
+</Layout>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -1,0 +1,19 @@
+---
+import Layout from "../layouts/Layout.astro";
+---
+<Layout title="Terms of Use">
+  <section class="prose mx-auto p-6">
+    <h1>Terms of Use</h1>
+    <p><strong>Effective Date: January 1, 2024</strong></p>
+    <p>Welcome to Track Attack Running, LLC ("Track Attack Running," "we," "us," or "our"). These Terms of Use govern your access to and use of our website and coaching services.</p>
+    <h2>Use of Our Services</h2>
+    <p>Our coaching content is provided for educational and informational purposes only. Fitness guidance is <strong>not medical advice</strong>. Always consult with a physician before beginning any new exercise program.</p>
+    <h2>Liability</h2>
+    <p>By participating in any workouts or following our guidance, you assume all risks. Track Attack Running, LLC is not liable for any injuries or damages that may result.</p>
+    <h2>Intellectual Property</h2>
+    <p>All content on this site is the property of Track Attack Running, LLC unless otherwise noted. You may not reproduce or distribute our content without permission.</p>
+    <h2>Contact Us</h2>
+    <p>If you have questions about these Terms, please contact us at:</p>
+    <address>Track Attack Running, LLC<br>1117 River Rock Drive<br>Folsom, CA 95630</address>
+  </section>
+</Layout>


### PR DESCRIPTION
## Summary
- refresh header/footer with gradient and logo overlap
- add Terms of Use and Privacy Policy pages
- keep Netlify form name `track-attack-running-contact-us`

## Testing
- `npm ci --no-audit --no-fund` *(failed: command not found: npm)*
- `npm run build` *(failed: command not found: npm)*
- `apt-get update` *(failed: repository not signed; 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899c3e1e8b48329bb12dbdd336b00ef